### PR TITLE
Updated documentation for Che 7 with NFS as persistent volume

### DIFF
--- a/che7/maap-k8sconfig-patch.yaml
+++ b/che7/maap-k8sconfig-patch.yaml
@@ -3,9 +3,9 @@ spec:
     ingressStrategy: 'single-host'
   server:
     cheImage: 'mas.maap-project.org:5000/root/che7/che-server'
-    cheImageTag: '7.23.1-maap'
+    cheImageTag: '7.25.2-maap-efs'
     cheImagePullPolicy: Always
-    devfileRegistryImage: 'mas.maap-project.org:5000/root/che-devfile-registry:7.23.1-maap'
+    devfileRegistryImage: 'mas.maap-project.org:5000/root/che-devfile-registry:7.25.2-maap'
     customCheProperties:
       CHE_LIMITS_USER_WORKSPACES_RUN_COUNT: '-1'
       CHE_INFRA_KUBERNETES_POD_SECURITY__CONTEXT_FS__GROUP: '0'
@@ -13,15 +13,16 @@ spec:
       CHE_INFRA_KUBERNETES_SERVER__STRATEGY: 'single-host'
       CHE_INFRA_KUBERNETES_SINGLEHOST_WORKSPACE_DEVFILE__ENDPOINT__EXPOSURE: 'single-host'
       CHE_LIMITS_WORKSPACE_IDLE_TIMEOUT: '604800000' # in milliseconds, 7 days hour before auto stopping workspace
-      CHE_INFRA_KUBERNETES_NAMESPACE_DEFAULT: '<username>-<workspaceid>'
+      CHE_INFRA_KUBERNETES_PVC_STORAGE__CLASS__NAME: 'nfs-client-che'
   database:
     # when set to true, the operator skips deploying Postgres, and passes connection details of existing DB to Che server
     # otherwise a Postgres deployment is created
     externalDb: false
     # Postgres deployment in format image:tag. 
-    postgresImage: 'mas.maap-project.org:5000/root/che7/che-postgres:7.23.1-maap'
+    postgresImage: 'mas.maap-project.org:5000/root/che7/che-postgres:7.25.2-maap-efs'
   auth:
     # instructs operator on whether or not to deploy Keycloak/RH SSO instance. When set to true provision connection details
     externalIdentityProvider: false
     # image:tag used in Keycloak deployment
-    identityProviderImage: 'mas.maap-project.org:5000/root/che7/che-keycloak:7.23.1-maap'
+    identityProviderImage: 'mas.maap-project.org:5000/root/che7/che-keycloak:7.25.2-maap-efs'
+

--- a/che7/microk8s/ingress-prd.yaml
+++ b/che7/microk8s/ingress-prd.yaml
@@ -10,10 +10,10 @@ metadata:
 spec:
   tls:
   - hosts:
-    - ade.che7test.xyz
+    - ade.ops.maap-project.org
     secretName: default-tls-secret
   rules:
-  - host: ade.che7test.xyz
+  - host: ade.ops.maap-project.org
   - http:
       paths:
       - path: /

--- a/che7/nfs-client-che-sc.yaml
+++ b/che7/nfs-client-che-sc.yaml
@@ -1,0 +1,11 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: nfs-client-che
+parameters:
+  pathPattern: "che/${.PVC.namespace}-${.PVC.name}" # waits for nfs.io/storage-path annotation, if not specified will accept as empty string.
+  archiveOnDelete: "true"
+provisioner: cluster.local/nfs-subdir-external-provisioner # or choose another name, must match deployment's env PROVISIONER_NAME'
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+allowVolumeExpansion: true

--- a/setup-commands-v7-microk8s.md
+++ b/setup-commands-v7-microk8s.md
@@ -1,50 +1,89 @@
+# Eclipse Che 7 with MicroK8S and EFS
+This installation will create the MAAP ADE with Eclipse Che 7 in `single-host` mode. It uses an NFS volume for its persistent Kubernetes volumes.
+
+## Configure EC2 instance
+The cluster node will be an EC2 instance of the type `r5.8xlarge`  running `Ubuntu 18.04` with 100GB `gp3` in the EBS root volume.
+
+## OS Configuration
 ```shell
 sudo apt-get update
 sudo apt-get -y dist-upgrade
-sudo snap install microk8s --classic --channel=1.19/stable
-# Snap update required for the libseccomp library
-sudo snap refresh 
 
-# For GCC, need to install cilium. Currently there's a bug https://github.com/ubuntu/microk8s/issues/1603
-# so you'll need to enable it, ctrl-c it when it appears to hang with "0 of 1 updated pods..." (2-3 of these messages)
-# Then disable it. Wait a bit, and re-enable it. Make sure that when you re-enable it that it re-downloads
-# cilium. If it says it's already enabled, you didn't wait long enough.
-sudo microk8s.enable cilium;
-sudo microk8s.disable cilium;
-# Wait until the command "sudo microk8s.kubectl get pods --all-namespaces" returns only healthy, running pods.
-sudo microk8s.enable cilium;
-# End GCC
-
-sudo microk8s.enable ingress; sleep 1;
-sudo microk8s.enable storage; sleep 1;
-sudo microk8s.enable dns; sleep 1;
-sudo microk8s.enable registry
-
+# Allows DNS progagation. In GCC, since it won't let us use alternative DNSs, this doesn't really matter but just to be consistent.
 sudo iptables -P INPUT ACCEPT
 sudo iptables -P OUTPUT ACCEPT
 sudo iptables -P FORWARD ACCEPT # for dns propogation
 sudo iptables -F
-sudo apt-get install iptables-persistent
+sudo apt-get install -y iptables-persistent
 
-# Install kubectl, required for chectl
-sudo snap install kubectl --classic 
+# [FS-CACHE for NFS clients | Frederik's Blog](https://blog.frehi.be/2019/01/03/fs-cache-for-nfs-clients/)
+sudo apt-get install -y nfs-common cachefilesd
+# uncomment RUN="yes" in /etc/default/cachefilesd
+sudo service cachefilesd start
+```
+
+## Set up /etc/fstab for the NFS mount
+```shell
+sudo mkdir /efs
+# get mount target
+echo "$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone).fs-<EFSID>.efs.us-west-2.amazonaws.com"
+# add `<mount-target-DNS>:/ /efs nfs4 nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport,_netdev,fsc 0 0` to /etc/fstab
+# [Additional mounting considerations - Amazon Elastic File System](https://docs.aws.amazon.com/efs/latest/ug/mounting-fs-mount-cmd-general.html)
+sudo mount -a
+```
+
+## MicroK8S Snap Installation
+```shell
+sudo snap install microk8s --classic --channel=1.20/stable
+sudo snap install kubectl --classic --channel=1.20/stable  # Install kubectl, required for chectl
+# Snap update required for the libseccomp library
+sudo snap refresh 
+
+sudo mkdir ~/.kube
 sudo usermod -a -G microk8s ubuntu
 sudo chown -f -R ubuntu ~/.kube
-[log back in]
+sudo microk8s.config | cat - > $HOME/.kube/config
+# Log out and back in
 
-microk8s.config | cat - > $HOME/.kube/config
+# Install cilium, it solves networking in GCC. First, wait until calico is fully initialied by looking at the pods.
+sudo microk8s.enable helm3
+sudo microk8s.enable cilium # may need to wait several minutes, be patient
+sudo ip link delete vxlan.calico
+# Following allows clustering to work, i.e. microk8s add-node/join, with cilium.
+sudo cp /var/snap/microk8s/2074/actions/cilium.yaml /var/snap/microk8s/2074/args/cni-network/cni.yaml
 
-##### If deploying to GCC:
-# note this temporary workaround for cert acquistion issues: https://github.com/jetstack/cert-manager/issues/2442#issuecomment-564955495
-# update the name server by running microk8s.kubectl -n kube-system edit configmap/coredns
-# the nameserver can be found by running cat /run/systemd/resolve/resolv.conf
-#####
+# STOP HERE if this node is going to be a worker node.
+
+sudo microk8s.enable storage; sleep 1;
+
+# Install NFS provisioner
+sudo microk8s.helm3 repo add nfs-subdir-external-provisioner https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner/
+sudo microk8s.helm3 install nfs-subdir-external-provisioner nfs-subdir-external-provisioner/nfs-subdir-external-provisioner \
+    --set nfs.server=<ipaddr of efs as nfs> \
+    --set nfs.path=/
+
+# Set NFS provisioner as default
+kubectl patch storageclass microk8s-hostpath -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
+kubectl patch storageclass nfs-client -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+
+sudo microk8s.enable ingress; sleep 5;
+sudo microk8s.enable dns:10.49.0.2; sleep 5; # needed for GCC as it blocks dns queries other than the local resolver
+# sudo microk8s.enable dns; sleep 5; # needed any normal cluster
+sudo microk8s.enable registry
+
+# Edit ingress daemonset to set ingress class back to nginx, change `--ingress-class=public` to `--ingress-class=nginx`. Not sure why it's called public in 1.20, but it breaks the default settings in other components if it's not `nginx`
+microk8s.kubectl edit daemonset -n ingress nginx-ingress-microk8s-controller
+
+# Set up cluster at this point
+microk8s add-node # on head machine
+microk8s join... # on worker machine
+microk8s.kubectl get nodes # verify!
 
 # Create a new namespace for the cert-manager
-kubectl create namespace cert-manager
+microk8s.kubectl create namespace cert-manager
 
 # Apply the official yaml file 
-kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.14.2/cert-manager.yaml
+microk8s.kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.2.0/cert-manager.yaml
 
 # Install chectl
 bash <(curl -sL  https://www.eclipse.org/che/chectl/)
@@ -54,14 +93,21 @@ wget https://raw.githubusercontent.com/MAAP-Project/maap-eclipseche-ops/master/c
 wget https://raw.githubusercontent.com/MAAP-Project/maap-eclipseche-ops/master/che7/microk8s/ingress-prd.yaml 
 # (updated domain in ingress-prd.yaml)
 
-kubectl apply -f prod.yaml 
-kubectl apply -f ingress-prd.yaml 
+microk8s.kubectl apply -f prod.yaml
+microk8s.kubectl apply -f ingress-prd.yaml
 
 # Ensure the following returns a value of 'True' before proceeding
-kubectl get cert
+microk8s.kubectl get cert
+
+# Deploy nfs-client-che storage class
+microk8s.kubectl apply -f nfs-client-che-sc.yaml
+
+# Verify microk8s.status, chectl uses this to verify that microk8s is running. If the following command takes too long, set permissions
+# [microk8s.status takes forever (almost 2 minutes) as user but not as sudo · Issue #884 · ubuntu/microk8s · GitHub](https://github.com/ubuntu/microk8s/issues/884)
+microk8s.status
 
 # Deploy Che
-chectl server:deploy --installer=operator --platform=microk8s --che-operator-cr-patch-yaml=maap-k8sconfig-patch.yaml --domain={REPLACE_ME} --multiuser --chenamespace=default
+chectl server:deploy --installer=operator --platform=microk8s --che-operator-cr-patch-yaml=maap-k8sconfig-patch.yaml --multiuser --domain={REPLACE_ME} 
 
 kubectl edit daemonset nginx-ingress-microk8s-controller -n ingress   
 # If needed by IT security, add the following setting to ensure http requests are signed in spec/template/spec/containers/args
@@ -70,8 +116,24 @@ kubectl edit daemonset nginx-ingress-microk8s-controller -n ingress
 # nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
 
 # DONE!
+```
 
-# To completely reset the system (you probably don't need this):
+# Resetting MicroK8S
+```
+# Remove node from cluster if it's in a clustered configuration
+sudo microk8s leave
+sudo microk8s remove-node...
+
 sudo microk8s.reset
 sudo snap remove microk8s --purge
+sudo snap remove kubectl --purge
+sudo rm -rf ~/.kube
+sudo rm -rf /var/snap/microk8s
+sudo rm -rf /var/snap/kubectl
+sudo rm -rf ~/snap/microk8s
+sudo rm -rf ~/snap/kubectl
+sudo rm -rf /root/snap/microk8s
+sudo rm -rf /root/snap/kubectl
+# sudo ip addr
+# sudo ip link delete <device> any orphaned network, i.e. things that have `cilium` or `calico` in them
 ```

--- a/setup-commands-v7-microk8s.md
+++ b/setup-commands-v7-microk8s.md
@@ -66,8 +66,8 @@ sudo microk8s.helm3 install nfs-subdir-external-provisioner nfs-subdir-external-
     --set nfs.path=/
 
 # Set NFS provisioner as default
-kubectl patch storageclass microk8s-hostpath -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
-kubectl patch storageclass nfs-client -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+microk8s.kubectl patch storageclass microk8s-hostpath -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
+microk8s.kubectl patch storageclass nfs-client -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
 
 sudo microk8s.enable ingress; sleep 5;
 sudo microk8s.enable dns:10.49.0.2; sleep 5; # needed for GCC as it blocks dns queries other than the local resolver
@@ -113,10 +113,15 @@ microk8s.status
 # Deploy Che
 chectl server:deploy --installer=operator --platform=microk8s --che-operator-cr-patch-yaml=maap-k8sconfig-patch.yaml --multiuser --domain={REPLACE_ME} 
 
-kubectl edit daemonset nginx-ingress-microk8s-controller -n ingress   
-# If needed by IT security, add the following setting to ensure http requests are signed in spec/template/spec/containers/args
+
+# If needed by IT security, do the following
+
+# Ensure http requests are signed in spec/template/spec/containers/args
+microk8s.kubectl  edit daemonset nginx-ingress-microk8s-controller -n ingress
 #  - --default-ssl-certificate=default/default-tls-secret
-# If needed by IT security, add the following annotation to ensure that *all* http requests are forwarded to https
+
+# Add the following annotation to ensure that *all* http requests are forwarded to https
+microk8s.kubectl  edit ingress
 # nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
 
 # DONE!

--- a/setup-commands-v7-microk8s.md
+++ b/setup-commands-v7-microk8s.md
@@ -89,6 +89,7 @@ microk8s.kubectl apply --validate=false -f https://github.com/jetstack/cert-mana
 bash <(curl -sL  https://www.eclipse.org/che/chectl/)
 
 wget https://raw.githubusercontent.com/MAAP-Project/maap-eclipseche-ops/master/che7/maap-k8sconfig-patch.yaml
+wget https://raw.githubusercontent.com/MAAP-Project/maap-eclipseche-ops/master/che7/nfs-client-che-sc.yaml
 wget https://raw.githubusercontent.com/MAAP-Project/maap-eclipseche-ops/master/che7/microk8s/prod.yaml 
 wget https://raw.githubusercontent.com/MAAP-Project/maap-eclipseche-ops/master/che7/microk8s/ingress-prd.yaml 
 # (updated domain in ingress-prd.yaml)


### PR DESCRIPTION
Also updated instructions to deploy Microk8s/Kubernetes 1.20 which allows us to define a dns directly from the microk8s.enable dns instead of having to edit the config map. Also updated cert-manager to the latest stable version.